### PR TITLE
Ocultar texto de productos cuando hay icono en la tabla de pedidos

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -743,7 +743,7 @@ function construirLineasPorProducto(o) {
     const icono = prod?.icono || '';
     const iconos = icono ? `${icono}×${cant}` : `${cant}x`;
     const vars = (o.variantes && o.variantes[nombre]) ? o.variantes[nombre] : null;
-    lineas.push({ nombre, cantidad: cant, iconos, variantes: vars });
+    lineas.push({ nombre, cantidad: cant, iconos, variantes: vars, tieneIcono: !!icono });
   }
   lineas.sort((a,b) => a.nombre.localeCompare(b.nombre));
   return lineas;
@@ -800,12 +800,15 @@ function actualizarTabla() {
           ? `<div class="productos-nombre indentado">${
               Object.keys(l.variantes).map(v=>`${html(v)}: ${l.variantes[v]}`).join(' · ')
             }</div>` : '';
+        const nombreProducto = l.tieneIcono
+          ? ''
+          : `<span class="productos-nombre">${html(l.nombre)}</span>`;
         productosHTML += `
           <div class="productos-linea">
             <input type="checkbox" class="pendiente-checkbox" ${checked}
               onclick="toggleEntrega('${o.fecha}','${jsEsc(l.nombre)}')">
             <span>${html(l.iconos)}</span>
-            <span class="productos-nombre">(${html(l.nombre)})</span>
+            ${nombreProducto}
             ${desglose}
           </div>
         `;


### PR DESCRIPTION
## Summary
- ocultar el nombre del producto en la tabla de pedidos cuando dispone de icono configurado
- mostrar el nombre únicamente como respaldo para productos sin icono, manteniendo el desglose de variantes existente

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d6ca09a98c8329aff81bdec4b4704d