### PR TITLE
Remove secondary scroll from order column

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -39,8 +39,6 @@
     display:flex;
     flex-direction:column;
     gap:12px;
-    max-height:calc(100vh - 120px);
-    overflow:auto;
     padding-right:4px;
   }
 


### PR DESCRIPTION
## Summary
- remove the constrained height and overflow on the order column so it no longer shows an inner scroll bar

## Testing
- Manual visual inspection


------
https://chatgpt.com/codex/tasks/task_e_68d6ca332f448329b573772e37069b9a