### PR TITLE
Evitar selección inicial en menú radial de variantes

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -648,11 +648,9 @@ function abrirRadial(nombre, punto, anchorEl) {
         cercano = meta;
       }
     }
-    const UMBRAL = 90;
+    const UMBRAL = Math.min(OFFSET_X * 0.8, 50);
     setActivo(cercano && distanciaMin <= UMBRAL ? cercano.el : null);
   };
-
-  actualizarDesdePunto({ x:cx, y:cy });
 
   const moverHandler = (e) => {
     if (e.type === 'mousemove' && e.buttons === 0) return;


### PR DESCRIPTION
## Summary
- evitar que el menú radial preseleccione automáticamente una variante al abrirse
- ajustar el umbral de detección para requerir que el cursor/dedo se acerque realmente a una opción antes de seleccionarla

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6e974df5c83299a84698a220d5122