### PR TITLE
Make action buttons compact and restore product grid

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -191,7 +191,7 @@
   /* Grid productos */
   .grid {
     display:grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap:10px;
   }
   .producto {
@@ -226,11 +226,6 @@
     transition:background 0.2s ease;
   }
   .eliminar-todos-btn:hover { background:#b71c1c; }
-  .boton-enviar {
-    border:3px solid #2e7d32;
-    background-color:#2e7d32;
-    color:#fff;
-  }
   table { margin:16px auto; width:100%; border-collapse:collapse; }
   th, td { border:1px solid #ddd; padding:8px; vertical-align: middle; text-align:left; }
   .resumen-panel {
@@ -370,7 +365,7 @@
     gap:10px;
     flex-wrap:wrap;
     justify-content:flex-start;
-    align-items:stretch;
+    align-items:center;
   }
   .metodo-pago .pago-label {
     flex:1 1 140px;
@@ -378,20 +373,93 @@
     padding:7px 20px;
   }
   .metodo-pago .cuenta-abierta-btn {
-    flex:1 1 140px;
-    padding:10px 20px;
-    margin:5px;
+    flex:0 0 auto;
+    margin:0;
   }
   .metodos-acciones .botones-acciones {
-    display:grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap:8px;
+    display:flex;
+    align-items:center;
+    gap:12px;
+    position:relative;
   }
   .metodos-acciones button {
     margin:0;
   }
-  .metodos-acciones .botones-acciones button {
-    padding:4.2px 14px;
+
+  .accion-redonda {
+    width:60px;
+    height:60px;
+    border-radius:50%;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-weight:700;
+    font-size:11px;
+    line-height:1.1;
+    text-align:center;
+    word-break:break-word;
+    padding:0 8px;
+    border:none;
+    margin:0;
+    box-shadow:0 6px 20px rgba(0,0,0,0.18);
+    transition:transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .accion-redonda:active { transform:scale(0.96); }
+  .accion-redonda:hover { box-shadow:0 8px 24px rgba(0,0,0,0.22); }
+  .accion-redonda:focus-visible {
+    outline:3px solid #fff;
+    outline-offset:2px;
+    box-shadow:0 0 0 4px rgba(57,73,171,0.45);
+  }
+
+  .boton-enviar {
+    border:3px solid #2e7d32;
+    background-color:#2e7d32;
+    color:#fff;
+  }
+  .cuenta-abierta-btn.accion-redonda {
+    background:#fbc02d;
+    color:#4e342e;
+    font-weight:700;
+  }
+  .boton-limpiar-flotante {
+    position:fixed;
+    bottom:24px;
+    right:24px;
+    background:#546e7a;
+    color:#fff;
+    z-index:2400;
+  }
+
+  @media (max-width: 1024px) {
+    .accion-redonda {
+      width:54px;
+      height:54px;
+      font-size:10px;
+    }
+    .boton-limpiar-flotante {
+      bottom:18px;
+      right:18px;
+    }
+  }
+  @media (max-width: 640px) {
+    .grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  @media (max-width: 420px) {
+    .grid {
+      grid-template-columns:1fr;
+    }
+    .accion-redonda {
+      width:50px;
+      height:50px;
+      font-size:9px;
+    }
+    .boton-limpiar-flotante {
+      bottom:12px;
+      right:12px;
+    }
   }
   .btn-cierre-caja {
     background:#fdeaea;
@@ -782,12 +850,12 @@
           <div id="metodoPago" class="metodo-pago">
             <label class="pago-label active"><input type="radio" name="pago" value="efectivo" checked>Efectivo</label>
             <label class="pago-label"><input type="radio" name="pago" value="sinpe">Sinpe</label>
-            <button class="cuenta-abierta-btn" onclick="anadirACuentaAbierta()">Pendiente</button>
+            <button class="cuenta-abierta-btn accion-redonda" onclick="anadirACuentaAbierta()">Pendiente</button>
           </div>
 
           <div class="botones-acciones">
-            <button onclick="enviar()">Enviar</button>
-            <button onclick="borrar()">Limpiar</button>
+            <button class="boton-enviar accion-redonda" onclick="enviar()">Enviar</button>
+            <button class="accion-redonda boton-limpiar-flotante" onclick="borrar()" aria-label="Limpiar selección">Limpiar</button>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- shrink the circular action buttons for enviar, limpiar, and pendiente while unifying their styling
- float the limpiar button so it no longer occupies layout space near the product grid
- restore the product grid to three columns with responsive fallbacks on smaller screens

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7048f4a4c8329b61687cb00303c10