### PR TITLE
Center tab navigation buttons

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -188,14 +188,15 @@
   /* Tabs */
   .tabs {
     position:fixed;
-    top:16px;
-    left:16px;
+    top:8px;
+    left:50%;
+    transform:translateX(-50%);
     display:flex;
     gap:8px;
     align-items:center;
-    justify-content:flex-start;
-    margin:10px 0 10px var(--main-offset);
-    width:var(--main-width);
+    justify-content:center;
+    margin:0;
+    width:auto;
   }
   .tab-content { width:100%; margin:10px 0; }
 


### PR DESCRIPTION
## Summary
- center the tab navigation controls at the top of the viewport
- remove the offset-based layout so the buttons sit flush without margins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8db3dbd48329ab66f473654e5aca