### PR TITLE
Corrige cálculo y reporte del conteo de caja

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ La interfaz está dividida en pestañas que se ajustan según el flujo de trabaj
 
 - **Apertura**: permite registrar a la persona responsable del turno y configurar el fondo inicial en caja. También ofrece un desglose opcional por denominaciones para documentar con cuánto efectivo se empieza el día.
 - **Pedidos**: muestra la grilla de productos vendibles, el resumen del pedido actual, sugerencias de cambio y el historial de órdenes registradas. Desde aquí se crean cuentas abiertas, se marca el estado de entrega de cada producto y se abre un panel flotante con los pendientes por cliente o por producto.
-- **Cierre**: calcula la diferencia entre el efectivo esperado y el efectivo contado, reutilizando el desglose por denominaciones. Desde esta pestaña se envía un correo de cierre (vía EmailJS) con el resumen del día y se limpian las órdenes pagadas del almacenamiento local.
+- **Cierre**: calcula la diferencia entre el efectivo esperado y el efectivo contado, reutilizando el desglose por denominaciones. La tabla de conteo muestra el fondo de caja, el efectivo realmente recaudado, el esperado y la diferencia. Desde esta pestaña se envía un correo de cierre (vía EmailJS) con el resumen del día —incluyendo el efectivo real— y se limpian las órdenes pagadas del almacenamiento local.
 - **Productos**: expone un editor para mantener el catálogo. Cada fila permite cambiar nombre, precio, tipo (bebida/comida), icono y variantes. Los cambios se guardan en `localStorage` y se reflejan inmediatamente en la pestaña de pedidos.
 
 ## Lógica destacada en `rancho.html`
@@ -17,7 +17,7 @@ La interfaz está dividida en pestañas que se ajustan según el flujo de trabaj
 - **Cálculo inteligente de totales**: antes de mostrar el importe se evalúa si conviene armar combos bebida+comida utilizando el valor configurado en `PRECIO_COMBO`. El resumen resultante indica las líneas cobradas como combo y las unidades restantes a precio individual.
 - **Gestión de pendientes**: el historial guarda por orden la cantidad, método de pago y variantes pedidas. Con esa información se construyen vistas agrupadas por cliente y por producto. Cada línea puede marcarse como servida directamente desde el panel de pendientes o desde la tabla principal.
 - **Cuentas abiertas**: los pedidos pendientes se agrupan por nombre de cliente. Cuando se cierra una cuenta, el sistema consolida los productos acumulados, solicita el método de pago y transforma el registro en una orden pagada que se incluye en los resúmenes.
-- **Apertura y cierre de caja**: la configuración de apertura persiste en `localStorage`, permitiendo recordar el fondo y el responsable elegido. Durante el cierre se calcula automáticamente la diferencia contra lo esperado y se prepara el correo de reporte con dos archivos CSV incrustados (resumen general e historial de ventas).
+- **Apertura y cierre de caja**: la configuración de apertura persiste en `localStorage`, permitiendo recordar el fondo y el responsable elegido. Durante el cierre se calcula automáticamente la diferencia contra lo esperado usando las ventas en efectivo registradas, se detalla el conteo real de caja y se prepara el correo de reporte con dos archivos CSV incrustados (resumen general e historial de ventas).
 - **Persistencia local**: productos, órdenes, cuentas abiertas y configuración de apertura se almacenan en `localStorage`. Esto permite trabajar sin conexión y conservar el estado entre recargas mientras se usa el mismo navegador.
 
 ## Flujo de uso recomendado

--- a/rancho.html
+++ b/rancho.html
@@ -816,6 +816,24 @@
     margin-top:16px;
     font-size:15px;
   }
+  .cierre-datos-conteo {
+    gap:10px;
+  }
+  .cierre-conteo-tabla {
+    width:100%;
+    border-collapse:collapse;
+  }
+  .cierre-conteo-tabla th {
+    text-align:left;
+    font-weight:600;
+  }
+  .cierre-conteo-tabla td {
+    text-align:right;
+  }
+  .cierre-conteo-tabla th,
+  .cierre-conteo-tabla td {
+    padding:4px 0;
+  }
   .diferencia {
     font-weight:bold;
   }
@@ -1039,8 +1057,6 @@
         </table>
         <div class="cierre-datos">
           <span>Responsable: <strong id="cierreResponsable">Glorilucas</strong></span>
-          <span>Fondo inicial: <strong id="cierreFondoInicial">10 000₡</strong></span>
-          <span>Efectivo esperado en caja: <strong id="cierreEsperado">10 000₡</strong></span>
         </div>
       </div>
       <div class="cierre-right cierre-card">
@@ -1063,9 +1079,27 @@
           </table>
           <div class="cash-total">Total contado: <span data-breakdown-total="cierre">0₡</span></div>
         </div>
-        <div class="cierre-datos">
-          <span>Efectivo contado: <strong id="cierreEfectivoContado">0₡</strong></span>
-          <span>Diferencia con fondo inicial: <strong id="cierreNeto">0₡</strong></span>
+        <div class="cierre-datos cierre-datos-conteo">
+          <table class="cierre-conteo-tabla">
+            <tbody>
+              <tr>
+                <th>Fondo de caja</th>
+                <td><strong id="cierreFondoInicial">10 000₡</strong></td>
+              </tr>
+              <tr>
+                <th>Efectivo recaudado</th>
+                <td><strong id="cierreEfectivoContado">0₡</strong></td>
+              </tr>
+              <tr>
+                <th>Efectivo esperado</th>
+                <td><strong id="cierreEsperado">10 000₡</strong></td>
+              </tr>
+              <tr>
+                <th>Diferencia</th>
+                <td><strong id="cierreDiferenciaValor">0₡</strong></td>
+              </tr>
+            </tbody>
+          </table>
           <span>Ventas en efectivo registradas: <strong id="cierreVentasEfectivo">0₡</strong></span>
           <span class="diferencia diferencia-neutro" id="cierreDiferencia">Cuadra (0₡)</span>
         </div>
@@ -1284,7 +1318,6 @@ function actualizarPanelCierre() {
   const ventasEfectivo = Number(ultimoResumen.efectivo || 0);
   const cierreInput = document.getElementById('cierreEfectivoInput');
   const contado = cierreInput ? parseColones(cierreInput.value) : 0;
-  const neto = contado - fondo;
   const esperado = fondo + ventasEfectivo;
   const diferencia = contado - esperado;
 
@@ -1296,10 +1329,10 @@ function actualizarPanelCierre() {
   if (esperadoSpan) esperadoSpan.textContent = `${formatearColones(esperado)}₡`;
   const contadoSpan = document.getElementById('cierreEfectivoContado');
   if (contadoSpan) contadoSpan.textContent = `${formatearColones(contado)}₡`;
-  const netoSpan = document.getElementById('cierreNeto');
-  if (netoSpan) netoSpan.textContent = `${formatearColones(neto)}₡`;
   const ventasSpan = document.getElementById('cierreVentasEfectivo');
   if (ventasSpan) ventasSpan.textContent = `${formatearColones(ventasEfectivo)}₡`;
+  const diferenciaValorSpan = document.getElementById('cierreDiferenciaValor');
+  if (diferenciaValorSpan) diferenciaValorSpan.textContent = `${formatearColones(diferencia)}₡`;
 
   const diffSpan = document.getElementById('cierreDiferencia');
   if (diffSpan) {
@@ -2002,6 +2035,12 @@ function actualizarTabla() {
     }
   }
 
+  ultimoResumen = {
+    efectivo: resumen.efectivo || 0,
+    sinpe: resumen.sinpe || 0,
+    total: resumen.total || 0
+  };
+  actualizarPanelCierre();
 }
 
 function eliminarOrden(fecha) {
@@ -2564,10 +2603,20 @@ function cerrarCaja() {
     });
   });
 
+  const cierreInput = document.getElementById('cierreEfectivoInput');
+  const efectivoContado = cierreInput ? parseColones(cierreInput.value) : 0;
+  const fondo = obtenerFondoInicial();
+  const efectivoEsperado = fondo + (resumen.efectivo || 0);
+  const diferenciaConteo = efectivoContado - efectivoEsperado;
+
   let tablaResumenTexto = "Resumen;Valor\n";
   tablaResumenTexto += `Total Recaudado;${resumen.total}₡\n`;
   tablaResumenTexto += `Total Efectivo;${resumen.efectivo || 0}₡\n`;
   tablaResumenTexto += `Total Sinpe;${resumen.sinpe || 0}₡\n`;
+  tablaResumenTexto += `Fondo de caja;${fondo}₡\n`;
+  tablaResumenTexto += `Efectivo real contado;${efectivoContado}₡\n`;
+  tablaResumenTexto += `Efectivo esperado;${efectivoEsperado}₡\n`;
+  tablaResumenTexto += `Diferencia conteo;${diferenciaConteo}₡\n`;
   for (let p in resumen.productos) {
     tablaResumenTexto += `Ventas de ${p};${resumen.productos[p]}\n`;
     const vars = resumen.variantes[p];


### PR DESCRIPTION
## Summary
- Corrige el cálculo del efectivo esperado tomando las ventas reales y sincroniza el panel de cierre con cada actualización del historial.
- Reestructura la sección de conteo de caja para mostrar una tabla con fondo inicial, efectivo recaudado, efectivo esperado y diferencia, ajustando estilos asociados.
- Añade el efectivo real contado, el fondo y la diferencia al correo de cierre y documenta el nuevo flujo en el README.

## Testing
- Revisión manual de la pestaña de cierre en el navegador.


------
https://chatgpt.com/codex/tasks/task_e_68da974a429c8329b49010242b9421e1