### PR TITLE
Corrige cálculo de total adeudado por casa

### DIFF
--- a/rancho.html
+++ b/rancho.html
@@ -3263,12 +3263,13 @@ function renderCasas() {
       card.innerHTML += construirMenuPagoCasa(numero, conteoTexto);
       const ul = document.createElement('ul');
       ul.className = 'casa-pedidos-list';
+      let totalAdeudado = 0;
       ordenados.forEach(o => {
         const li = document.createElement('li');
         li.className = 'casa-pedido';
         const productos = resumenProductosCorto(o) || '<span class="muted">Sin detalle</span>';
         const propinaOrden = normalizarPropina(o.propina);
-        total += (Number(o.cantidad) || 0) + propinaOrden;
+        totalAdeudado += (Number(o.cantidad) || 0) + propinaOrden;
         const resumenTexto = resumenProductosPlano(o);
         const iconos = construirIconosProductos(o);
         const iconosTitulo = resumenTexto ? ` title="${html(resumenTexto)}"` : '';
@@ -3293,7 +3294,7 @@ function renderCasas() {
 
       const totalDiv = document.createElement('div');
       totalDiv.className = 'casa-total';
-      totalDiv.innerHTML = `Total adeudado: <strong>${formatearColones(totalMonto)}₡</strong>`;
+      totalDiv.innerHTML = `Total adeudado: <strong>${formatearColones(totalAdeudado)}₡</strong>`;
       card.appendChild(totalDiv);
     }
 


### PR DESCRIPTION
## Summary
- declara un acumulador explícito antes de recorrer los pedidos en cada casa
- usa el acumulador para sumar montos y propinas y mostrar el total adeudado real

## Testing
- no se realizaron pruebas (entorno no interactivo)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912102cd9c4832993a8ec35b46f2f42)